### PR TITLE
Fix the default value of reporter input in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can supply this value one of three ways:
 
 - `files: '["input1", "input2"]'`: A list of file or directory arguments; equivalent to calling `vale input1 input2`.
 
-### `reporter` (default: github-check)
+### `reporter` (default: github-pr-check)
 
 Set the [reporter](https://github.com/reviewdog/reviewdog#reporters) type.
 


### PR DESCRIPTION
Hi!
I think the default value of `reporter` input in README.md should be `github-pr-check`.

https://github.com/errata-ai/vale-action/blob/c4213d4de3d5f718b8497bd86161531c78992084/action.yml#L24-L27