### PR TITLE
Adds instructions in README for viewing available flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ with:
 
 ### `vale_flags` (default: "")
 
-Space-delimited list of flags for the Vale CLI.
+Space-delimited list of flags for the Vale CLI. To see a full list of available flags, run `vale -h`.
 
 ```yaml
 with:


### PR DESCRIPTION
This PR expands the helper text under vale flags in the README file. Specifically, it addresses how to view the available flags. If there is a better resource, such as online documentation, perhaps it should be included instead of `vale -h`.