### PR TITLE
Remove single quotes from `vale_flags` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Space-delimited list of flags for the Vale CLI. To see a full list of available 
 
 ```yaml
 with:
-  vale_flags: "--glob='*.txt'"
+  vale_flags: "--glob=*.txt"
 ```
 
 [1]: https://help.github.com/en/github/automating-your-workflow-with-github-actions/configuring-a-workflow


### PR DESCRIPTION
Because of how this is executed (i.e. no shell), the quotes will actually end up being part of the glob pattern resulting in no matches 99.9% of the time.

Related issue https://github.com/errata-ai/vale-action/issues/75