### PR TITLE
Remove the need to explicitly pass GITHUB_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,3 @@ jobs:
           fail_on_error: true
           level: warning
           debug: true
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
-        env:
-          # Required, set by GitHub actions automatically:
-          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
 
 ## Repository Structure
@@ -129,6 +125,15 @@ Space-delimited list of flags for the Vale CLI. To see a full list of available 
 ```yaml
 with:
   vale_flags: "--glob=*.txt"
+```
+
+### `token` (default: [`secrets.GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication))
+
+The GitHub token to use.
+
+```yaml
+with:
+  token: ${{secrets.VALE_GITHUB_TOKEN}}
 ```
 
 [1]: https://help.github.com/en/github/automating-your-workflow-with-github-actions/configuring-a-workflow

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,11 @@ inputs:
     required: false
     default: ""
 
+  token:
+    description: "The GitHub token to use."
+    required: false
+    default: ${{ github.token }}
+
 runs:
   using: docker
   image: Dockerfile

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,7 +38,7 @@ const input = __importStar(require("./input"));
  *
  * See https://bit.ly/2WlFUD7 for more information.
  */
-const { GITHUB_TOKEN, GITHUB_WORKSPACE } = process.env;
+const { GITHUB_WORKSPACE } = process.env;
 function run(actionInput) {
     return __awaiter(this, void 0, void 0, function* () {
         const workdir = core.getInput('workdir') || '.';
@@ -53,7 +53,7 @@ function run(actionInput) {
                 const vale_code = output.exitCode;
                 const should_fail = core.getInput('fail_on_error');
                 // Pipe to reviewdog ...
-                process.env['REVIEWDOG_GITHUB_API_TOKEN'] = GITHUB_TOKEN;
+                process.env['REVIEWDOG_GITHUB_API_TOKEN'] = core.getInput('token');
                 return yield exec.exec('/bin/reviewdog', [
                     '-f=rdjsonl',
                     `-name=vale`,
@@ -85,7 +85,7 @@ exports.run = run;
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const userToken = GITHUB_TOKEN;
+            const userToken = core.getInput('token');
             const workspace = GITHUB_WORKSPACE;
             const actionInput = yield input.get(userToken, workspace);
             yield run(actionInput);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import * as input from './input';
  *
  * See https://bit.ly/2WlFUD7 for more information.
  */
-const {GITHUB_TOKEN, GITHUB_WORKSPACE} = process.env;
+const {GITHUB_WORKSPACE} = process.env;
 
 export async function run(actionInput: input.Input): Promise<void> {
   const workdir = core.getInput('workdir') || '.';
@@ -37,7 +37,7 @@ export async function run(actionInput: input.Input): Promise<void> {
         const should_fail = core.getInput('fail_on_error');
 
         // Pipe to reviewdog ...
-        process.env['REVIEWDOG_GITHUB_API_TOKEN'] = GITHUB_TOKEN;
+        process.env['REVIEWDOG_GITHUB_API_TOKEN'] = core.getInput('token');
         return await exec.exec(
           '/bin/reviewdog',
           [
@@ -71,7 +71,7 @@ export async function run(actionInput: input.Input): Promise<void> {
 
 async function main(): Promise<void> {
   try {
-    const userToken = GITHUB_TOKEN as string;
+    const userToken = core.getInput('token');
     const workspace = GITHUB_WORKSPACE as string;
 
     const actionInput = await input.get(userToken, workspace);


### PR DESCRIPTION
This PR removes the need to explicitly pass a GitHub token as an action input. This helps a little to reduce the amount of configuration needed. You can still pass a different token explicitly if you want to.

GitHub's documentation on Actions doesn't really explain how to do this very clearly, but basically you have to set a default value for the token in `action.yml` that uses `${{ github.token }}`.

For example here are some examples of GitHub's own actions that use this approach:

- https://github.com/actions/checkout/blob/2541b1294d2704b0964813337f33b291d3f8596b/action.yml#L24
- https://github.com/actions/deploy-pages/blob/791c72a9c00a798aeb2a9e602f7ff515b5624bd5/action.yml#L14
- https://github.com/actions/stale/blob/33e37032bbf25592761040e9c94772c16e52e9a4/action.yml#L8