### PR TITLE
Fix --level reviewdog option when fail_on_error is false

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -60,7 +60,7 @@ function run(actionInput) {
                     `-reporter=${core.getInput('reporter')}`,
                     `-fail-on-error=${should_fail}`,
                     `-filter-mode=${core.getInput('filter_mode')}`,
-                    `-level=${vale_code == 1 && should_fail ? 'error' : 'info'}`
+                    `-level=${vale_code == 1 && should_fail === 'true' ? 'error' : 'info'}`
                 ], {
                     cwd,
                     input: Buffer.from(output.stdout, 'utf-8'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,9 @@ export async function run(actionInput: input.Input): Promise<void> {
             `-reporter=${core.getInput('reporter')}`,
             `-fail-on-error=${should_fail}`,
             `-filter-mode=${core.getInput('filter_mode')}`,
-            `-level=${vale_code == 1 && should_fail ? 'error' : 'info'}`
+            `-level=${
+              vale_code == 1 && should_fail === 'true' ? 'error' : 'info'
+            }`
           ],
           {
             cwd,


### PR DESCRIPTION
### Description

According to [the definition](https://github.com/actions/toolkit/blob/a6bf8726aa7b78d4fc8111359cca5d538527b239/packages/core/src/core.ts#L126) of the `core.getInput` function, the return type is a `string`:
```ts
/**
 * Gets the value of an input.
 * Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
 * Returns an empty string if the value is not defined.
 *
 * @param     name     name of the input to get
 * @param     options  optional. See InputOptions.
 * @returns   string
 */
export function getInput(name: string, options?: InputOptions): string {
```

The default assigned to the value is [also a string](https://github.com/daniele-pini/vale-action/blob/79437a5f4618c447e00addeb4a94011f97aeb266/action.yml#L29-L34):
```yml
  fail_on_error:
    description: |
      Exit code for reviewdog when errors are found [true,false]
      Default is `false`.
    required: false
    default: "false"
```

Except `fail_on_error` was used like a boolean in code. This PR fixes the comparison to check against the `'true'` string value.