### PR TITLE
Make Reviewdog URL an input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,11 @@ inputs:
     required: false
     default: ""
 
+  reviewdog_url:
+    description: "The URL to a tar.gz build of reviewdog to use in the action"
+    required: false
+    default: ""
+
   token:
     description: "The GitHub token to use."
     required: false

--- a/lib/input.js
+++ b/lib/input.js
@@ -69,7 +69,7 @@ function get(tok, dir) {
         yield exec.exec('gem', ['install', 'asciidoctor', '--user-install']);
         logIfDebug('`gem install asciidoctor --user-install` complete');
         const localVale = yield (0, install_1.installLint)(core.getInput('version'));
-        const localReviewDog = yield (0, install_1.installReviewDog)("0.15.0");
+        const localReviewDog = yield (0, install_1.installReviewDog)("0.15.0", core.getInput('reviewdog_url'));
         const valeFlags = core.getInput("vale_flags");
         let version = '';
         yield exec.exec(localVale, ['-v'], {

--- a/lib/install.js
+++ b/lib/install.js
@@ -65,10 +65,12 @@ function installLint(version) {
     });
 }
 exports.installLint = installLint;
-function installReviewDog(version) {
+function installReviewDog(version, url) {
     return __awaiter(this, void 0, void 0, function* () {
         core.info(`Installing ReviewDog version '${version}' ...`);
-        const url = `https://github.com/reviewdog/reviewdog/releases/download/v${version}/reviewdog_${version}_Linux_x86_64.tar.gz`;
+        if (!url) {
+            url = `https://github.com/reviewdog/reviewdog/releases/download/v${version}/reviewdog_${version}_Linux_x86_64.tar.gz`;
+        }
         const archivePath = yield tc.downloadTool(url);
         let extractedDir = '';
         const args = ['xz'];
@@ -77,7 +79,7 @@ function installReviewDog(version) {
         }
         extractedDir = yield tc.extractTar(archivePath, process.env.HOME, args);
         const reviewdogPath = path_1.default.join(extractedDir, `reviewdog`);
-        core.info(`Installed version '${version}' into '${reviewdogPath}'.`);
+        core.info(`Installed reviewdog from '${url}' into '${reviewdogPath}'.`);
         return reviewdogPath;
     });
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -58,7 +58,7 @@ export async function get(tok: string, dir: string): Promise<Input> {
   logIfDebug('`gem install asciidoctor --user-install` complete');
 
   const localVale = await installLint(core.getInput('version'));
-  const localReviewDog = await installReviewDog("0.15.0");
+  const localReviewDog = await installReviewDog("0.15.0", core.getInput('reviewdog_url'));
   const valeFlags = core.getInput("vale_flags");
 
   let version = '';

--- a/src/install.ts
+++ b/src/install.ts
@@ -31,10 +31,13 @@ export async function installLint(version: string): Promise<string> {
   return lintPath;
 }
 
-export async function installReviewDog(version: string): Promise<string> {
+export async function installReviewDog(version: string, url?: string): Promise<string> {
   core.info(`Installing ReviewDog version '${version}' ...`);
   
-  const url = `https://github.com/reviewdog/reviewdog/releases/download/v${version}/reviewdog_${version}_Linux_x86_64.tar.gz`;
+  if (!url){
+    url = `https://github.com/reviewdog/reviewdog/releases/download/v${version}/reviewdog_${version}_Linux_x86_64.tar.gz`;
+  }
+
   const archivePath = await tc.downloadTool(url);
 
   let extractedDir = '';
@@ -47,7 +50,7 @@ export async function installReviewDog(version: string): Promise<string> {
   extractedDir = await tc.extractTar(archivePath, process.env.HOME, args);
 
   const reviewdogPath = path.join(extractedDir, `reviewdog`);
-  core.info(`Installed version '${version}' into '${reviewdogPath}'.`);
 
+  core.info(`Installed reviewdog from '${url}' into '${reviewdogPath}'.`);
   return reviewdogPath;
 }


### PR DESCRIPTION
This PR adds support for specifying a custom `reviewdog_url`. This allows people to use a specific version, or a fork of reviewdog if necessary.