### PR TITLE
Use GH Annotations via ReviewDog to associate output with the correct check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,9 @@ inputs:
     default: "false"
 
   reporter:
-    description: "Reporter of reviewdog command [github-pr-check,github-pr-review,github-check]."
+    description: "Reporter of reviewdog command [github-pr-check,github-pr-review,github-pr-annotations,github-check]."
     required: false
-    default: "github-pr-check"
+    default: "github-pr-annotations"
 
   fail_on_error:
     description: |

--- a/lib/input.js
+++ b/lib/input.js
@@ -69,7 +69,7 @@ function get(tok, dir) {
         yield exec.exec('gem', ['install', 'asciidoctor', '--user-install']);
         logIfDebug('`gem install asciidoctor --user-install` complete');
         const localVale = yield (0, install_1.installLint)(core.getInput('version'));
-        const localReviewDog = yield (0, install_1.installReviewDog)("0.15.0", core.getInput('reviewdog_url'));
+        const localReviewDog = yield (0, install_1.installReviewDog)("0.17.0", core.getInput('reviewdog_url'));
         const valeFlags = core.getInput("vale_flags");
         let version = '';
         yield exec.exec(localVale, ['-v'], {

--- a/src/input.ts
+++ b/src/input.ts
@@ -58,7 +58,7 @@ export async function get(tok: string, dir: string): Promise<Input> {
   logIfDebug('`gem install asciidoctor --user-install` complete');
 
   const localVale = await installLint(core.getInput('version'));
-  const localReviewDog = await installReviewDog("0.15.0", core.getInput('reviewdog_url'));
+  const localReviewDog = await installReviewDog("0.17.0", core.getInput('reviewdog_url'));
   const valeFlags = core.getInput("vale_flags");
 
   let version = '';


### PR DESCRIPTION
Resolves #73 

ReviewDog added support for a GH annotation reporter, which will attach check output to the job that runs Vale rather than a random job.

This PR updates ReviewDog and switches the default reporter.