### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Los_Angeles"


### PR DESCRIPTION
This will help keep CI dependencies up to date. With the recent NodeJS 16 EoL, many "component" actions such as `actions/checkout` are throwing warnings/getting updates.  This is already fixed for `vale-action` itself, but several of the CI workflows have out of date deps.

More info here:

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

### Testing
You can see the PRs that this config will open in my fork here:

https://github.com/wadells/vale-action/pulls/app%2Fdependabot