### PR TITLE
#97: Catch Vale runtime errors properly

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -48,7 +48,7 @@ function run(actionInput) {
         const workdir = core.getInput('workdir') || '.';
         const cwd = path.relative(process.env['GITHUB_WORKSPACE'] || process.cwd(), workdir);
         try {
-            const code = yield core.group('Running vale with reviewdog 🐶 ...', () => __awaiter(this, void 0, void 0, function* () {
+            const code = yield core.group('Running vale...', () => __awaiter(this, void 0, void 0, function* () {
                 // Vale output ...
                 const output = yield exec.getExecOutput(actionInput.exePath, actionInput.args, {
                     cwd,
@@ -58,8 +58,17 @@ function run(actionInput) {
                     }
                 });
                 const vale_code = output.exitCode;
+                'Vale return code: ${vale_code}';
+                // Check for fatal runtime errors only (exit code 2)
+                // These aren't linting errors, but ones that will come
+                // about from missing or bad configuration files, etc.
+                if (vale_code === 2) {
+                    core.setFailed(`Vale encountered a fatal error with status code: ${vale_code}`);
+                    return 2; // Exit the function early
+                }
                 const should_fail = core.getInput('fail_on_error');
                 // Pipe to reviewdog ...
+                core.info('Calling reviewdog 🐶');
                 process.env['REVIEWDOG_GITHUB_API_TOKEN'] = core.getInput('token');
                 return yield exec.exec(actionInput.reviewdogPath, [
                     '-f=rdjsonl',
@@ -75,7 +84,7 @@ function run(actionInput) {
                 });
             }));
             if (code !== 0) {
-                core.setFailed(`reviewdog exited with status code: ${code}`);
+                core.setFailed(`Vale and reviewdog exited with status code: ${code}`);
             }
         }
         catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ export async function run(actionInput: input.Input): Promise<void> {
 
   try {
     const code = await core.group(
-      'Running vale with reviewdog 🐶 ...',
+      'Running vale...',
       async (): Promise<number> => {
         // Vale output ...
         const output = await exec.getExecOutput(
@@ -37,9 +37,19 @@ export async function run(actionInput: input.Input): Promise<void> {
         );
 
         const vale_code = output.exitCode;
+        'Vale return code: ${vale_code}'
+        // Check for fatal runtime errors only (exit code 2)
+        // These aren't linting errors, but ones that will come
+        // about from missing or bad configuration files, etc.
+        if (vale_code === 2) {
+          core.setFailed(`Vale encountered a fatal error with status code: ${vale_code}`);
+          return 2; // Exit the function early
+        }
+
         const should_fail = core.getInput('fail_on_error');
 
         // Pipe to reviewdog ...
+        core.info('Calling reviewdog 🐶');
         process.env['REVIEWDOG_GITHUB_API_TOKEN'] = core.getInput('token');
         return await exec.exec(
           actionInput.reviewdogPath,
@@ -62,7 +72,7 @@ export async function run(actionInput: input.Input): Promise<void> {
     );
 
     if (code !== 0) {
-      core.setFailed(`reviewdog exited with status code: ${code}`);
+      core.setFailed(`Vale and reviewdog exited with status code: ${code}`);
     }
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
Per #97, if the Vale invocation fails, the GitHub action doesn't fail. 
This means that linting workflows that are misconfigured (or in which a misconfiguration creeps in subsequently) will fail silently.

Since Vale will [return exit code 2](https://github.com/errata-ai/vale/blob/v3/cmd/vale/main.go#L81) if there is a runtime failure, this PR updates the action to handle exit code 2. At the moment only 1 (a linting error) is handled.

I am no TS/JS expert so please feel free to make suggestions where I've done something stupid :)
