### PR TITLE
Update reviewdog from 0.17.0 to 0.20.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: ./ # Uses an action in the root directory
         with:
           reporter: github-check
-          fail_on_error: true
+          fail_level: any
           level: warning
           debug: true

--- a/README.md
+++ b/README.md
@@ -129,15 +129,16 @@ with:
   reporter: github-pr-check
 ```
 
-### `fail_on_error` (default: false)
+### `fail_level` (default: error)
 
-By default, `reviewdog` will return exit code `0` even if it finds errors. If 
-`fail_on_error` is enabled, `reviewdog` exits with `1` when at least one error
-was reported.
+Controls the exit code of `reviewdog` depending on the severity of issues reported by Vale. For example, if
+`fail_level: warning`, then `reviewdog` will exit with 0 when all alerts have `info` severity, while it will exit with
+1 if there are any alerts with `error`, `warning`, or `unknown` severity.
 
 ```yaml
 with:
-  fail_on_error: true
+  # none, any, error, warning, info
+  fail_level: error
 ```
 
 ### `filter_mode` (default: added)

--- a/action.yml
+++ b/action.yml
@@ -26,15 +26,23 @@ inputs:
     required: false
     default: "github-pr-annotations"
 
+  fail_level:
+    description: |
+      Default is 'error'.
+      Level which causes the check to fail [none,any,error,warning,info]
+    required: false
+    default: error
+
   fail_on_error:
     description: |
+      Deprecated. Use `fail_level` instead.
       Exit code for reviewdog when errors are found [true,false]
       Default is `false`.
     required: false
     default: "false"
 
   level:
-    description: "Report level for reviewdog [info,warning,error]."
+    description: "This parameter is ignored. Report level for reviewdog [info,warning,error]."
     required: false
     default: "error"
 

--- a/lib/input.js
+++ b/lib/input.js
@@ -64,7 +64,7 @@ function logIfDebug(msg) {
 function get(tok, dir) {
     return __awaiter(this, void 0, void 0, function* () {
         const localVale = yield (0, install_1.installLint)(core.getInput('version'));
-        const localReviewDog = yield (0, install_1.installReviewDog)("0.17.0", core.getInput('reviewdog_url'));
+        const localReviewDog = yield (0, install_1.installReviewDog)("0.20.3", core.getInput('reviewdog_url'));
         const valeFlags = core.getInput("vale_flags");
         let version = '';
         yield exec.exec(localVale, ['-v'], {

--- a/lib/main.js
+++ b/lib/main.js
@@ -65,6 +65,7 @@ function run(actionInput) {
                 if (vale_code === 2) {
                     return 2; // Exit the function early
                 }
+                const fail_level = core.getInput('fail_level');
                 const should_fail = core.getInput('fail_on_error');
                 // Pipe to reviewdog ...
                 core.info('Calling reviewdog 🐶');
@@ -73,6 +74,7 @@ function run(actionInput) {
                     '-f=rdjsonl',
                     `-name=vale`,
                     `-reporter=${core.getInput('reporter')}`,
+                    `-fail-level=${fail_level}`,
                     `-fail-on-error=${should_fail}`,
                     `-filter-mode=${core.getInput('filter_mode')}`,
                     `-level=${vale_code == 1 && should_fail === 'true' ? 'error' : 'info'}`

--- a/src/input.ts
+++ b/src/input.ts
@@ -50,7 +50,7 @@ function logIfDebug(msg: string) {
  */
 export async function get(tok: string, dir: string): Promise<Input> {
   const localVale = await installLint(core.getInput('version'));
-  const localReviewDog = await installReviewDog("0.17.0", core.getInput('reviewdog_url'));
+  const localReviewDog = await installReviewDog("0.20.3", core.getInput('reviewdog_url'));
   const valeFlags = core.getInput("vale_flags");
 
   let version = '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ export async function run(actionInput: input.Input): Promise<void> {
           return 2; // Exit the function early
         }
 
+        const fail_level = core.getInput('fail_level');
         const should_fail = core.getInput('fail_on_error');
 
         // Pipe to reviewdog ...
@@ -56,9 +57,11 @@ export async function run(actionInput: input.Input): Promise<void> {
             '-f=rdjsonl',
             `-name=vale`,
             `-reporter=${core.getInput('reporter')}`,
+            `-fail-level=${fail_level}`,
             `-fail-on-error=${should_fail}`,
             `-filter-mode=${core.getInput('filter_mode')}`,
-            `-level=${vale_code == 1 && should_fail === 'true' ? 'error' : 'info'
+            `-level=${
+              vale_code == 1 && should_fail === 'true' ? 'error' : 'info'
             }`
           ],
           {


### PR DESCRIPTION
- The new reviewdog option `-fail-level` will hopefully help with issues like https://github.com/reviewdog/reviewdog/issues/1407 where vale-action fails even when it shouldn't.
The reviewdog option `-fail-on-error` has been deprecated.
- The "level" parameter is not obeyed, so clarified that in the action.yml