### PR TITLE
feat: allow use of local version of vale

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ block. For example:
 
 > NOTE: The provided version must be `>= 2.16.0`.
 
-Specify the Vale CLI version to use.
+Specify the Vale CLI version to use. If `none`, any preinstalled version of vale
+is used.
 
 ```yaml
 with:

--- a/lib/install.js
+++ b/lib/install.js
@@ -37,13 +37,35 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.installReviewDog = exports.installLint = void 0;
 const core = __importStar(require("@actions/core"));
+const exec = __importStar(require("@actions/exec"));
 const tc = __importStar(require("@actions/tool-cache"));
 const node_fetch_1 = __importDefault(require("node-fetch"));
 const path_1 = __importDefault(require("path"));
 const releases = 'https://github.com/errata-ai/vale/releases/download';
 const last = 'https://github.com/errata-ai/vale/releases/latest/';
+function lookupLint() {
+    return __awaiter(this, void 0, void 0, function* () {
+        let path = '';
+        let stderr = '';
+        let resp = yield exec.exec('which', ['vale'], {
+            listeners: {
+                stdout: (buffer) => (path = buffer.toString().trim()),
+                stderr: (data) => (stderr += data.toString())
+            }
+        });
+        if (resp !== 0) {
+            core.setFailed(stderr);
+        }
+        core.info(`Using the install at ${path}`);
+        return path;
+    });
+}
 function installLint(version) {
     return __awaiter(this, void 0, void 0, function* () {
+        if (version === 'none') {
+            core.info(`Assuming a version of vale is already available.`);
+            return yield lookupLint();
+        }
         core.info(`Installing Vale version '${version}' ...`);
         if (version === 'latest') {
             const response = yield (0, node_fetch_1.default)(last);

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import * as exec from '@actions/exec';
 import * as tc from '@actions/tool-cache';
 import fetch from 'node-fetch';
 import path from 'path';
@@ -6,7 +7,31 @@ import path from 'path';
 const releases = 'https://github.com/errata-ai/vale/releases/download';
 const last = 'https://github.com/errata-ai/vale/releases/latest/';
 
+async function lookupLint(): Promise<string> {
+  let path = '';
+  let stderr = '';
+
+  let resp = await exec.exec('which', ['vale'], {
+    listeners: {
+      stdout: (buffer: Buffer) => (path = buffer.toString().trim()),
+      stderr: (data: Buffer) => (stderr += data.toString())
+    }
+  });
+
+  if (resp !== 0) {
+    core.setFailed(stderr);
+  }
+
+  core.info(`Using the install at ${path}`)
+  return path;
+}
+
 export async function installLint(version: string): Promise<string> {
+  if (version === 'none') {
+    core.info(`Assuming a version of vale is already available.`);
+    return await lookupLint();
+  }
+
   core.info(`Installing Vale version '${version}' ...`);
   if (version === 'latest') {
     const response = await fetch(last);


### PR DESCRIPTION
If a container already has a version of vale available allow users to specify version = "none" to use that instead of installing a new version.

---

Example execution logs:
https://github.com/StaticRocket/processor-sdk-doc/actions/runs/15077894711/job/42389217242?pr=6